### PR TITLE
Update module to v2 and dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,7 +267,7 @@ jobs:
           echo "## Installation" >> release_notes.md
           echo "" >> release_notes.md
           echo '```bash' >> release_notes.md
-          echo "go get github.com/username/reveald-http@v${VERSION}" >> release_notes.md
+          echo "go get github.com/username/reveald-http/v2@v${VERSION}" >> release_notes.md
           echo '```' >> release_notes.md
           echo "" >> release_notes.md
           echo "## Usage" >> release_notes.md

--- a/README.md
+++ b/README.md
@@ -1,1 +1,211 @@
-# reveald-http - exposing reveald via HTTP
+# reveald-http
+
+A Go HTTP library that exposes the [reveald](https://github.com/reveald/reveald) search backend via HTTP endpoints. Build powerful search APIs with minimal configuration.
+
+## Features
+
+- **Simple HTTP Wrapper**: Expose reveald search functionality through HTTP endpoints
+- **Flexible Routing**: Configure multiple routes with different search capabilities
+- **Feature-Rich Search**: Built-in support for pagination, sorting, filtering, and histograms
+- **Middleware Support**: Standard HTTP middleware pattern for authentication, logging, and more
+- **Elasticsearch Backend**: Powered by Elasticsearch through the reveald abstraction layer
+- **OpenTelemetry Ready**: Auto-instrumentation support for observability
+- **Customizable**: Configure parameter readers, loggers, and backend options
+
+## Installation
+
+```bash
+go get github.com/reveald/http/v2
+```
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "fmt"
+    "net/http"
+
+    revealdhttp "github.com/reveald/http/v2"
+    "github.com/reveald/reveald/featureset"
+    "github.com/reveald/reveald/v2"
+)
+
+func main() {
+    // Create an Elasticsearch backend
+    backend, err := reveald.NewElasticBackend([]string{"http://localhost:9200"})
+    if err != nil {
+        panic(err)
+    }
+
+    // Create the HTTP API
+    api := revealdhttp.New(backend)
+
+    // Configure a search route
+    api.Route("/search",
+        revealdhttp.WithIndex("my-index"),
+        revealdhttp.WithFeatures(
+            featureset.NewPaginationFeature(),
+            featureset.NewSortingFeature("sort"),
+        ))
+
+    // Start the server
+    http.ListenAndServe(":8080", api)
+}
+```
+
+Visit `http://localhost:8080/search` to see search results.
+
+## API Reference
+
+### Creating an API
+
+```go
+api := revealdhttp.New(backend, options...)
+```
+
+**Options:**
+- `WithLogger(logger)` - Set a custom logger
+- `WithParamReader(readers...)` - Set custom parameter readers for extracting search parameters from HTTP requests
+
+### Configuring Routes
+
+```go
+api.Route(pattern, options...)
+```
+
+**Route Options:**
+- `WithIndex(index)` - Specify which Elasticsearch index to search (can be called multiple times)
+- `WithFeatures(features...)` - Add reveald features (pagination, sorting, filtering, etc.)
+- `WithMiddleware(handler)` - Add HTTP middleware for the route
+
+### Available Features
+
+Features are provided by the `github.com/reveald/reveald/featureset` package:
+
+- **Pagination**: `featureset.NewPaginationFeature()`
+- **Sorting**: `featureset.NewSortingFeature(paramName, options...)`
+- **Static Filtering**: `featureset.NewStaticFilterFeature(options...)`
+  - `WithRequiredProperty(field)` - Filter by field presence
+  - `WithRequiredValue(field, value)` - Filter by exact value
+- **Dynamic Filtering**: `featureset.NewDynamicFilterFeature(field)` - User-controlled filtering via query parameters
+- **Histograms**: `featureset.NewHistogramFeature(field, options...)`
+
+## Examples
+
+### Advanced Search Endpoint
+
+```go
+api.Route("/products/search",
+    // Add custom middleware
+    revealdhttp.WithMiddleware(authMiddleware),
+
+    // Search in multiple indices
+    revealdhttp.WithIndex("products"),
+    revealdhttp.WithIndex("product-variants"),
+
+    // Add search features
+    revealdhttp.WithFeatures(
+        featureset.NewPaginationFeature(),
+        featureset.NewSortingFeature("sort",
+            featureset.WithSortOption("by-price", "price", false),
+            featureset.WithSortOption("by-date", "created_at", true)),
+        featureset.NewStaticFilterFeature(
+            featureset.WithRequiredValue("status", "active")),
+        featureset.NewDynamicFilterFeature("category"),
+        featureset.NewDynamicFilterFeature("brand"),
+        featureset.NewHistogramFeature("price",
+            featureset.WithInterval(100)),
+    ))
+```
+
+### Custom Middleware
+
+```go
+func authMiddleware(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        token := r.Header.Get("Authorization")
+        if token == "" {
+            http.Error(w, "Unauthorized", http.StatusUnauthorized)
+            return
+        }
+        next.ServeHTTP(w, r)
+    })
+}
+```
+
+### Custom Logger
+
+```go
+type CustomLogger struct{}
+
+func (l *CustomLogger) Errorf(format string, args ...any) {
+    log.Printf("ERROR: "+format, args...)
+}
+
+api := revealdhttp.New(backend,
+    revealdhttp.WithLogger(&CustomLogger{}))
+```
+
+## Development
+
+### Prerequisites
+
+- Go 1.25+
+- Docker (for running Elasticsearch locally)
+
+### Local Development
+
+```bash
+# Start local Elasticsearch
+./examples/local-elasticsearch.sh
+
+# Seed with test data
+./examples/seed-elasticsearch.sh
+
+# Run the example server
+go run examples/main.go
+
+# Run tests
+go test ./...
+
+# Build
+go build ./...
+```
+
+### Running the Example
+
+The example server demonstrates a complete setup with pagination, sorting, filtering, and histograms:
+
+```bash
+go run examples/main.go
+```
+
+Then navigate to:
+- `http://localhost:8080/search` - View search results
+- `http://localhost:8080/search?text_field=Third` - Filtered results
+- Add `Authorization` header to see middleware in action
+
+## Architecture
+
+The library follows a clean separation of concerns:
+
+- **HTTPAPI** (`server.go`): Main HTTP server managing routes and middleware
+- **Route** (`route.go`): Route configuration with indices, features, and middleware
+- **Handler** (`handler.go`): Creates reveald endpoints and executes searches
+- **ParamReader** (`reader.go`): Extracts search parameters from HTTP requests
+- **Result** (`result.go`): Formats search results as JSON responses
+
+## Dependencies
+
+- [github.com/reveald/reveald](https://github.com/reveald/reveald) - Core search functionality
+- [github.com/elastic/go-elasticsearch/v8](https://github.com/elastic/go-elasticsearch) - Elasticsearch client
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit issues or pull requests.
+
+## Related Projects
+
+- [reveald](https://github.com/reveald/reveald) - The core search backend library

--- a/examples/main.go
+++ b/examples/main.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	revealdhttp "github.com/reveald/http"
-	"github.com/reveald/reveald"
+	revealdhttp "github.com/reveald/http/v2"
 	"github.com/reveald/reveald/featureset"
+	"github.com/reveald/reveald/v2"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,16 @@
-module github.com/reveald/http
+module github.com/reveald/http/v2
 
 go 1.25
 
-require github.com/reveald/reveald v1.0.0
+require github.com/reveald/reveald/v2 v2.0.0
 
 require (
 	github.com/elastic/elastic-transport-go/v8 v8.7.0 // indirect
 	github.com/elastic/go-elasticsearch/v8 v8.19.0 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/otel v1.36.0 // indirect
-	go.opentelemetry.io/otel/metric v1.36.0 // indirect
-	go.opentelemetry.io/otel/trace v1.36.0 // indirect
+	go.opentelemetry.io/otel v1.38.0 // indirect
+	go.opentelemetry.io/otel/metric v1.38.0 // indirect
+	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
+github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
@@ -75,6 +77,8 @@ github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/reveald/reveald v1.0.0 h1:Yc1nBI2zQGrTpBPCimVTwEHjVvp2PZXoxKVQ789682o=
 github.com/reveald/reveald v1.0.0/go.mod h1:ofuT5x3KVbbXIs7FVTREbBayhsq0wJ6OQrdS9myARfw=
+github.com/reveald/reveald/v2 v2.0.0 h1:4ZeE6BrwTVDyLcBr9LGBgU4YYodt0/vvVcCGEPF39fc=
+github.com/reveald/reveald/v2 v2.0.0/go.mod h1:hepBgKMfCCtxSwK7WGkJ7FEOxUvVdG4chCbGCJZlfEA=
 github.com/shirou/gopsutil/v4 v4.25.1 h1:QSWkTc+fu9LTAWfkZwZ6j8MSUk4A2LV7rbH0ZqmLjXs=
 github.com/shirou/gopsutil/v4 v4.25.1/go.mod h1:RoUCUpndaJFtT+2zsZzzmhvbfGoDCJ7nFXKJf8GqJbI=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
@@ -97,12 +101,18 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 h1:jq9TW8u
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0/go.mod h1:p8pYQP+m5XfbZm9fxtSKAbM6oIllS7s2AfxrChvc7iw=
 go.opentelemetry.io/otel v1.36.0 h1:UumtzIklRBY6cI/lllNZlALOF5nNIzJVb16APdvgTXg=
 go.opentelemetry.io/otel v1.36.0/go.mod h1:/TcFMXYjyRNh8khOAO9ybYkqaDBb/70aVwkNML4pP8E=
+go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=
+go.opentelemetry.io/otel v1.38.0/go.mod h1:zcmtmQ1+YmQM9wrNsTGV/q/uyusom3P8RxwExxkZhjM=
 go.opentelemetry.io/otel/metric v1.36.0 h1:MoWPKVhQvJ+eeXWHFBOPoBOi20jh6Iq2CcCREuTYufE=
 go.opentelemetry.io/otel/metric v1.36.0/go.mod h1:zC7Ks+yeyJt4xig9DEw9kuUFe5C3zLbVjV2PzT6qzbs=
+go.opentelemetry.io/otel/metric v1.38.0 h1:Kl6lzIYGAh5M159u9NgiRkmoMKjvbsKtYRwgfrA6WpA=
+go.opentelemetry.io/otel/metric v1.38.0/go.mod h1:kB5n/QoRM8YwmUahxvI3bO34eVtQf2i4utNVLr9gEmI=
 go.opentelemetry.io/otel/sdk v1.21.0 h1:FTt8qirL1EysG6sTQRZ5TokkU8d0ugCj8htOgThZXQ8=
 go.opentelemetry.io/otel/sdk v1.21.0/go.mod h1:Nna6Yv7PWTdgJHVRD9hIYywQBRx7pbox6nwBnZIxl/E=
 go.opentelemetry.io/otel/trace v1.36.0 h1:ahxWNuqZjpdiFAyrIoQ4GIiAIhxAunQR6MUoKrsNd4w=
 go.opentelemetry.io/otel/trace v1.36.0/go.mod h1:gQ+OnDZzrybY4k4seLzPAWNwVBBVlF2szhehOBB/tGA=
+go.opentelemetry.io/otel/trace v1.38.0 h1:Fxk5bKrDZJUH+AMyyIXGcFAPah0oRcT+LuNtJrmcNLE=
+go.opentelemetry.io/otel/trace v1.38.0/go.mod h1:j1P9ivuFsTceSWe1oY+EeW3sc+Pp42sO++GHkg4wwhs=
 golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=
 golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
 golang.org/x/mod v0.16.0 h1:QX4fJ0Rr5cPQCF7O9lh9Se4pmwfwskqZfq5moyldzic=

--- a/handler.go
+++ b/handler.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/reveald/reveald"
+	"github.com/reveald/reveald/v2"
 )
 
 func queryResultHandler(b reveald.Backend, r *Route, l Logger, read ParamReader) http.HandlerFunc {

--- a/reader.go
+++ b/reader.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/reveald/reveald"
+	"github.com/reveald/reveald/v2"
 )
 
 func QueryReader(r *http.Request) ([]reveald.Parameter, error) {

--- a/result.go
+++ b/result.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/reveald/reveald"
+	"github.com/reveald/reveald/v2"
 )
 
 type Result struct {

--- a/route.go
+++ b/route.go
@@ -3,7 +3,7 @@ package http
 import (
 	"net/http"
 
-	"github.com/reveald/reveald"
+	"github.com/reveald/reveald/v2"
 )
 
 type Route struct {

--- a/server.go
+++ b/server.go
@@ -3,7 +3,7 @@ package http
 import (
 	"net/http"
 
-	"github.com/reveald/reveald"
+	"github.com/reveald/reveald/v2"
 )
 
 type HTTPAPI struct {


### PR DESCRIPTION
Changes the module path to github.com/reveald/http/v2 and updates the dependency on github.com/reveald/reveald to v2.0.0. Additionally, updates the go-logr/logr and OpenTelemetry packages to their latest versions. The README has been expanded to provide detailed usage instructions and examples for the new version.
